### PR TITLE
wlan: Address buffer overflow due to invalid length

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
@@ -5895,6 +5895,9 @@ int wlan_hdd_set_filter(hdd_context_t *pHddCtx, tpPacketFilterCfg pRequest,
 
                 hddLog(VOS_TRACE_LEVEL_INFO, "Data Offset %d Data Len %d\n",
                         pRequest->paramsData[i].dataOffset, pRequest->paramsData[i].dataLength);
+                if ((sizeof(packetFilterSetReq.paramsData[i].compareData)) <
+                    (pRequest->paramsData[i].dataLength))
+                    return -EINVAL;
 
                 memcpy(&packetFilterSetReq.paramsData[i].compareData,
                         pRequest->paramsData[i].compareData, pRequest->paramsData[i].dataLength);


### PR DESCRIPTION
Check for valid length before copying the packet filter data from
userspace buffer to kernel space buffer to avoid buffer overflow
issue.

Change-Id: Icfdcbb41a7266a2d1a87816d4e6803747002cff0
CRs-Fixed: 930533
(cherry picked from commit 1859110643f8e52b17a52e6edc3518737c3337cb)